### PR TITLE
Fix a case in day 12 solution

### DIFF
--- a/day_12/solution.py
+++ b/day_12/solution.py
@@ -11,6 +11,8 @@ def make_graph(inputs):
     for i, j in inputs:
         if i == "start":
             g[i] += (j,)
+        elif j == "start":
+            g[j] += (i,)
         else:
             g[i] += (j,)
             g[j] += (i,)


### PR DESCRIPTION
In example 2, the solution was wrong (`156` vs `103`) because `start` was occuring in the middle of some paths. For example, `('start', 'HN', 'start', 'HN', 'dc', 'kj', 'HN', 'end')` was counted as a valid path, but it shouldn't be.

This PR fixes that by changing graph so that `start` is not accessible from any node.